### PR TITLE
Attempt to fix ConstraintError on sync

### DIFF
--- a/src/matrix/room/room.js
+++ b/src/matrix/room/room.js
@@ -13,7 +13,7 @@ export default class Room extends EventEmitter {
         this._hsApi = hsApi;
 		this._summary = new RoomSummary(roomId);
         this._fragmentIdComparer = new FragmentIdComparer([]);
-		this._syncWriter = new SyncWriter({roomId, storage, fragmentIdComparer: this._fragmentIdComparer});
+		this._syncWriter = new SyncWriter({roomId, fragmentIdComparer: this._fragmentIdComparer});
         this._emitCollectionChange = emitCollectionChange;
         this._sendQueue = new SendQueue({roomId, storage, sendScheduler, pendingEvents});
         this._timeline = null;

--- a/src/matrix/room/timeline/persistence/SyncWriter.js
+++ b/src/matrix/room/timeline/persistence/SyncWriter.js
@@ -18,9 +18,8 @@ function deduplicateEvents(events) {
 }
 
 export default class SyncWriter {
-    constructor({roomId, storage, fragmentIdComparer}) {
+    constructor({roomId, fragmentIdComparer}) {
         this._roomId = roomId;
-        this._storage = storage;
         this._fragmentIdComparer = fragmentIdComparer;
         this._lastLiveKey = null;
     }


### PR DESCRIPTION
Attempt to fix #16 

The reason #16 occurs is because in a room there was an event with a fragmentId (2) (and the default first eventIndex `80000000`) that didn't have a fragment in the `timelineFragments` store. When trying to persist a limited sync, the `SyncWriter` would have found the last fragment to be 1 (that's the last fragment present in the store) and on limited sync, tried to increment the fragmentId to 2, and set the eventIndex to the default `80000000`. For the combination fragmentId 2 and eventIndex 800000000, there is already an event present, so the `key` collides when calling `add` on the `timelineEvents` store, and the txn fails with a `ConstraintError`.

The only reason I could think how this could have happened (insert an event with a fragmentId that doesn't have a fragment in the `timelineFragments` store) is because the transaction failed when (but potentially failed unrelated to) adding a new fragment when writing a limited sync. The sync stopped and showed the error. SyncWriter._lastLiveKey would also have been incremented though, as it's immediately updated in the code. Then the user pressed "try syncing" (no refresh) and syncing for some weird reason I can't explain yet now did succeed (but wasn't limited anymore because the last fragment was 1 and the non-existing fragmentId was 2, not 3, so no extra increment for attempting to write the gappy sync twice), so an event was written with the already adjusted lastLiveKey in the SyncWriter. 

This only updates lastLiveKey in all cases (including when adding a fragment) when the transaction succeeds.

As it's hard to reproduce, the plan is to merge this and see if the errors still occurs (after clearing the storage).