### PR TITLE
Fix: remote id not being stored when receiving /send response

### DIFF
--- a/src/matrix/room/sending/SendQueue.js
+++ b/src/matrix/room/sending/SendQueue.js
@@ -43,7 +43,7 @@ export default class SendQueue {
                         pendingEvent.eventType,
                         pendingEvent.txnId,
                         pendingEvent.content
-                    );
+                    ).response();
                 });
                 pendingEvent.remoteId = response.event_id;
                 // 


### PR DESCRIPTION
Related https://github.com/bwindels/brawl-chat/issues/29

we were reading back a remote id of undefined because of this,
so when for some reason we never receive the message down from sync,
the pending message keeps sending on every load. The server ignores
the send though, because the transaction id is already used, and it returns
the remote id of the event that was already sent the previous time, but
as we were not storing this remote id, we'd just try again and again.

not receiving it through sync could have happened when we were sending a bunch of events
and then receiving (this is how we encountered this bug, while trying to repro another) the
response, but not yet the sync for the message that got wedged. Then we typed stuff on another client
so we would get a limited response for that room, and boom, we would not get the remote echo of the
event that was already sent (but because of this bug we didn't store the remote id) but no echo received yet (when we remove the pending event),
so it gets wedged!

Conclusion: this is a good start, but we also need to detect remote echos when back-paginating, and at some point do that automatically.