### PR TITLE
Fix: update previous fragment in comparer when appending a new live fragment

### DIFF
--- a/src/matrix/room/timeline/FragmentIdComparer.js
+++ b/src/matrix/room/timeline/FragmentIdComparer.js
@@ -142,13 +142,6 @@ export default class FragmentIdComparer {
 
     rebuild(fragments) {
         const islands = createIslands(fragments);
-        const fragmentJson = JSON.stringify(islands.map(i => {
-            return Array.from(i._idToSortIndex.entries())
-                .map(([id, idx]) => {return {id, idx};})
-                .sort((a, b) => a.idx - b.idx);
-        }));
-        const firstFragment = this._fragmentsById.values().next().value;
-        console.log("rebuilt fragment index", firstFragment && firstFragment.roomId, fragmentJson);
         this._idToIsland = new Map();
         for(let island of islands) {
             for(let id of island.fragmentIds) {

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -33,13 +33,7 @@ export default class Timeline {
 
     /** @package */
     appendLiveEntries(newEntries) {
-        try {
-            this._remoteEntries.setManySorted(newEntries);
-        } catch (err) {
-            console.error("error while appending live entries in roomId", this._roomId);
-            console.error(err.stack);
-            throw err;
-        }
+        this._remoteEntries.setManySorted(newEntries);
     }
 
     /** @public */

--- a/src/matrix/room/timeline/persistence/SyncWriter.js
+++ b/src/matrix/room/timeline/persistence/SyncWriter.js
@@ -77,7 +77,7 @@ export default class SyncWriter {
             nextToken: null
         };
         txn.timelineFragments.add(newFragment);
-        this._fragmentIdComparer.add(newFragment);
+        this._fragmentIdComparer.append(newFragmentId, oldFragmentId);
         return {oldFragment, newFragment};
     }
 


### PR DESCRIPTION
Otherwise the new live fragment ended up in a new island, see https://github.com/bwindels/brawl-chat/issues/10

Fixes https://github.com/bwindels/brawl-chat/issues/10