### PR TITLE
Prevent fragment links corrupting when filling a gap and server returns duplicate events

### DIFF
--- a/doc/impl-thoughts/RECONNECTING.md
+++ b/doc/impl-thoughts/RECONNECTING.md
@@ -1,0 +1,1 @@
+# Reconnecting

--- a/src/matrix/room/timeline/Direction.js
+++ b/src/matrix/room/timeline/Direction.js
@@ -17,6 +17,10 @@ export default class Direction {
         return this.isForward ? "f" : "b";
     }
 
+    reverse() {
+        return this.isForward ? Direction.Backward : Direction.Forward
+    }
+
     static get Forward() {
         return _forward;
     }

--- a/src/matrix/room/timeline/EventKey.js
+++ b/src/matrix/room/timeline/EventKey.js
@@ -37,7 +37,11 @@ export default class EventKey {
     }
 
     static get defaultLiveKey() {
-        return new EventKey(Platform.minStorageKey, Platform.middleStorageKey);
+        return EventKey.defaultFragmentKey(Platform.minStorageKey);
+    }
+
+    static defaultFragmentKey(fragmentId) {
+        return new EventKey(fragmentId, Platform.middleStorageKey);
     }
 
     toString() {

--- a/src/matrix/room/timeline/persistence/GapWriter.js
+++ b/src/matrix/room/timeline/persistence/GapWriter.js
@@ -10,30 +10,75 @@ export default class GapWriter {
     }
     // events is in reverse-chronological order (last event comes at index 0) if backwards
     async _findOverlappingEvents(fragmentEntry, events, txn) {
-        const eventIds = events.map(e => e.event_id);
-        let nonOverlappingEvents = events;
+        let expectedOverlappingEventId;
+        if (fragmentEntry.hasLinkedFragment) {
+            expectedOverlappingEventId = await this._findExpectedOverlappingEventId(fragmentEntry, txn);
+        }
+        let remainingEvents = events;
+        let nonOverlappingEvents = [];
         let neighbourFragmentEntry;
-        const neighbourEventId = await txn.timelineEvents.findFirstOccurringEventId(this._roomId, eventIds);
-        if (neighbourEventId) {
-            // trim overlapping events
-            const neighbourEventIndex = events.findIndex(e => e.event_id === neighbourEventId);
-            nonOverlappingEvents = events.slice(0, neighbourEventIndex);
-            // get neighbour fragment to link it up later on
-            const neighbourEvent = await txn.timelineEvents.getByEventId(this._roomId, neighbourEventId);
-            const neighbourFragment = await txn.timelineFragments.get(this._roomId, neighbourEvent.fragmentId);
-            neighbourFragmentEntry = fragmentEntry.createNeighbourEntry(neighbourFragment);
+        while (remainingEvents && remainingEvents.length) {
+            const eventIds = remainingEvents.map(e => e.event_id);
+            const duplicateEventId = await txn.timelineEvents.findFirstOccurringEventId(this._roomId, eventIds);
+            if (duplicateEventId) {
+                const duplicateEventIndex = remainingEvents.findIndex(e => e.event_id === duplicateEventId);
+                // should never happen, just being defensive as this *can't* go wrong
+                if (duplicateEventIndex === -1) {
+                    throw new Error(`findFirstOccurringEventId returned ${duplicateEventIndex} which wasn't ` +
+                        `in [${eventIds.join(",")}] in ${this._roomId}`);
+                }
+                nonOverlappingEvents.push(...remainingEvents.slice(0, duplicateEventIndex));
+                if (!expectedOverlappingEventId || duplicateEventId === expectedOverlappingEventId) {
+                    // TODO: check here that the neighbourEvent is at the correct edge of it's fragment
+                    // get neighbour fragment to link it up later on
+                    const neighbourEvent = await txn.timelineEvents.getByEventId(this._roomId, duplicateEventId);
+                    const neighbourFragment = await txn.timelineFragments.get(this._roomId, neighbourEvent.fragmentId);
+                    neighbourFragmentEntry = fragmentEntry.createNeighbourEntry(neighbourFragment);
+                    // trim overlapping events
+                    remainingEvents = null;
+                } else {
+                    // we've hit https://github.com/matrix-org/synapse/issues/7164, 
+                    // e.g. the event id we found is already in our store but it is not
+                    // the adjacent fragment id. Ignore the event, but keep processing the ones after.
+                    remainingEvents = remainingEvents.slice(duplicateEventIndex + 1);
+                }
+            } else {
+                nonOverlappingEvents.push(...remainingEvents);
+                remainingEvents = null;
+            }
         }
         return {nonOverlappingEvents, neighbourFragmentEntry};
     }
 
-    async _findLastFragmentEventKey(fragmentEntry, txn) {
+    async _findExpectedOverlappingEventId(fragmentEntry, txn) {
+        const eventEntry = await this._findFragmentEdgeEvent(
+            fragmentEntry.linkedFragmentId,
+            // reverse because it's the oppose edge of the linked fragment
+            fragmentEntry.direction.reverse(),
+            txn);
+        if (eventEntry) {
+            return eventEntry.event.event_id;
+        }
+    }
+
+    async _findFragmentEdgeEventKey(fragmentEntry, txn) {
         const {fragmentId, direction} = fragmentEntry;
+        const event = await this._findFragmentEdgeEvent(fragmentId, direction, txn);
+        if (event) {
+            return new EventKey(event.fragmentId, event.eventIndex);
+        } else {
+            // no events yet in the fragment ... odd, but let's not fail and take the default key
+            return EventKey.defaultFragmentKey(fragmentEntry.fragmentId);
+        }
+    }
+
+    async _findFragmentEdgeEvent(fragmentId, direction, txn) {
         if (direction.isBackward) {
             const [firstEvent] = await txn.timelineEvents.firstEvents(this._roomId, fragmentId, 1);
-            return new EventKey(firstEvent.fragmentId, firstEvent.eventIndex);
+            return firstEvent;
         } else {
             const [lastEvent] = await txn.timelineEvents.lastEvents(this._roomId, fragmentId, 1);
-            return new EventKey(lastEvent.fragmentId, lastEvent.eventIndex);
+            return lastEvent;
         }
     }
 
@@ -57,8 +102,22 @@ export default class GapWriter {
         directionalAppend(entries, fragmentEntry, direction);
         // set `end` as token, and if we found an event in the step before, link up the fragments in the fragment entry
         if (neighbourFragmentEntry) {
-            fragmentEntry.linkedFragmentId = neighbourFragmentEntry.fragmentId;
-            neighbourFragmentEntry.linkedFragmentId = fragmentEntry.fragmentId;
+            // the throws here should never happen and are only here to detect client or unhandled server bugs
+            // and a last measure to prevent corrupting fragment links
+            if (!fragmentEntry.hasLinkedFragment) {
+                fragmentEntry.linkedFragmentId = neighbourFragmentEntry.fragmentId;
+            } else if (fragmentEntry.linkedFragmentId !== neighbourFragmentEntry.fragmentId) {
+                throw new Error(`Prevented changing fragment ${fragmentEntry.fragmentId} ` +
+                    `${fragmentEntry.direction.asApiString()} link from ${fragmentEntry.linkedFragmentId} ` +
+                    `to ${neighbourFragmentEntry.fragmentId} in ${this._roomId}`);
+            }
+            if (!neighbourFragmentEntry.hasLinkedFragment) {
+                neighbourFragmentEntry.linkedFragmentId = fragmentEntry.fragmentId;
+            } else if (neighbourFragmentEntry.linkedFragmentId !== fragmentEntry.fragmentId) {
+                throw new Error(`Prevented changing fragment ${neighbourFragmentEntry.fragmentId} ` +
+                    `${neighbourFragmentEntry.direction.asApiString()} link from ${neighbourFragmentEntry.linkedFragmentId} ` +
+                    `to ${fragmentEntry.fragmentId} in ${this._roomId}`);
+            }
             // if neighbourFragmentEntry was found, it means the events were overlapping,
             // so no pagination should happen anymore.
             neighbourFragmentEntry.token = null;
@@ -100,7 +159,7 @@ export default class GapWriter {
             throw new Error("start is not equal to prev_batch or next_batch");
         }
         // find last event in fragment so we get the eventIndex to begin creating keys at
-        let lastKey = await this._findLastFragmentEventKey(fragmentEntry, txn);
+        let lastKey = await this._findFragmentEdgeEventKey(fragmentEntry, txn);
         // find out if any event in chunk is already present using findFirstOrLastOccurringEventId
         const {
             nonOverlappingEvents,


### PR DESCRIPTION
ignore duplicate events from synapse instead considering them an
overlapping event with the adjacent fragment

Fixes https://github.com/bwindels/brawl-chat/issues/39
Fixes https://github.com/bwindels/brawl-chat/issues/15


 - [x] if the fragment is already linked up in the direction we're filling, look up the first event id we should encounter when filling overlaps with the adjacent fragment.
 - [x] when looking for overlapping events, check if the event is the event id expected when overlapping. If not, it means we've hit https://github.com/matrix-org/synapse/issues/7164 and we ignore the event as it is already present in the timeline elsewhere, and find the next overlapping id in the remaining events. Repeat this until either finding the expected overlapping event id or we've gone through all the events in the backfill.
 - [x] don't add fragments to the `FragmentIdComparer` until the transaction has been comitted. This is another case of modify-memory-state-before-commit.